### PR TITLE
Ensured it is safe for concurrent use,

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/alexaandru/vali)](https://goreportcard.com/report/github.com/alexaandru/vali)
 [![Go Reference](https://pkg.go.dev/badge/github.com/alexaandru/vali.svg)](https://pkg.go.dev/github.com/alexaandru/vali)
 
-**Vali**, a purposefully tiny validator. 🔋s are not included,
+**Vali**, a purposefully tiny validator. 🔋🔋🔋 are not included,
 but there are recipes on how to make them ☺️.
 
 Rather then a large collection of checks (which ultimately


### PR DESCRIPTION
although, you'd normally register all checks up front, and then only use them for validation. Outside of tests, it would be a weird scenario to run into, but better safe than sorry.