### PR TITLE
Simplified error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 **Vali**, a purposefully tiny validator. 🔋🔋🔋 are not included,
 but there are recipes on how to make them ☺️.
 
-Rather then a large collection of checks (which ultimately
+Rather than a large collection of checks (which ultimately
 imply many deps) I wanted to try and go for the most things
 I could do with the least amount of checks.
 

--- a/check.go
+++ b/check.go
@@ -9,10 +9,9 @@ import (
 
 // Possible errors.
 var (
-	ErrNotAStruct     = errors.New("not a struct")
-	ErrRequired       = errors.New("required value missing")
 	ErrFailed         = errors.New("failed")
-	ErrInvalidRegex   = fmt.Errorf("regex check %w", ErrFailed)
+	ErrNotAStruct     = errors.New("not a struct")
+	ErrRequired       = errors.New("value missing")
 	ErrInvalidChecker = errors.New("invalid checker")
 )
 
@@ -43,7 +42,7 @@ func Regex(args string) (c Checker, err error) {
 			return
 		}
 
-		return fmt.Errorf("%w: %q does not match %s", ErrInvalidRegex, act, args)
+		return fmt.Errorf("%q does not match %s", act, args)
 	}
 
 	return

--- a/example_test.go
+++ b/example_test.go
@@ -14,7 +14,7 @@ func ExampleValidationSet_Validate() {
 	}{}
 	err := vali.Validate(s)
 	fmt.Println(err)
-	// Output: Foo.Bar: required value missing
+	// Output: Foo.Bar: required check failed: value missing
 }
 
 func ExampleValidationSet_Validate_custom_checker() {
@@ -42,7 +42,7 @@ func ExampleValidationSet_Validate_custom_checker() {
 	err = vali.Validate(s)
 	fmt.Println(err) // this should not
 
-	// Output: Foo.Bar: regex check failed: "123" does not match ^\d{3}-?\d{3}-?\d{4}$
+	// Output: Foo.Bar: phone check failed: "123" does not match ^\d{3}-?\d{3}-?\d{4}$
 	// <nil>
 }
 


### PR DESCRIPTION
the validation framework now takes care of reporting the checker name and the checkers need only report what went wrong, i.e. no more:

"phone check failed: regex not matching ..." from checkers, instead: "regex not matching ..." and vali automatically adds the "phone check failed" part.